### PR TITLE
client-jongwon: react quill로 작성한 본문 스타일 수정

### DIFF
--- a/client/src/components/Answer/AnswerListView.style.ts
+++ b/client/src/components/Answer/AnswerListView.style.ts
@@ -1,4 +1,5 @@
 import styled from 'styled-components';
+import QuillContentBody from '../../styles/QuillContentBody.style';
 import { StyledBackgroundButton } from '../Button/BackgroundButton';
 import { StyledBorderButton } from '../Button/BorderButton';
 
@@ -51,7 +52,7 @@ export const NameZone = styled.span`
   flex-direction: row;
 `;
 
-export const TextArea = styled.div`
+export const TextArea = styled(QuillContentBody)`
   margin-left: 1rem;
   overflow: hidden;
 `;

--- a/client/src/components/Forum/ForumDetail.style.ts
+++ b/client/src/components/Forum/ForumDetail.style.ts
@@ -1,4 +1,5 @@
 import styled from 'styled-components';
+import QuillContentBody from '../../styles/QuillContentBody.style';
 
 export const Container = styled.section`
   width: 100%;
@@ -68,7 +69,7 @@ export const Title = styled.h3`
   font-size: calc(20 / 16 * 1rem);
 `;
 
-export const Content = styled.p`
+export const Content = styled(QuillContentBody)`
   padding: calc(20 / 16 * 1rem);
 
   @media screen and (max-width: 414px) {

--- a/client/src/components/Forum/ForumDetail.tsx
+++ b/client/src/components/Forum/ForumDetail.tsx
@@ -1,6 +1,6 @@
 import * as S from './ForumDetail.style';
 import { BackgroundOtherButton, SmallBorderTagButton, MoreButton } from '../Button';
-import { GRAY_LIST_FILL, GREEN_MAIN } from '../../assets/constant/COLOR';
+import { GRAY_LIST_FILL } from '../../assets/constant/COLOR';
 import ForumWrittenInfo from './ForumWrittenInfo';
 import { InlineIcon } from '@iconify/react';
 import DOMPurify from 'dompurify';
@@ -81,7 +81,6 @@ const ForumDetail = ({ page = 1 }: PropsType) => {
           </S.TitleInfoContainer>
 
           <S.Content
-            className="forum-content"
             dangerouslySetInnerHTML={{
               __html: DOMPurify.sanitize(post[`${forumType}Content`]),
             }}

--- a/client/src/styles/QuillContentBody.style.ts
+++ b/client/src/styles/QuillContentBody.style.ts
@@ -1,0 +1,92 @@
+import styled from 'styled-components';
+
+const QuillContentBody = styled.div`
+  p {
+    display: block;
+    margin-block-start: 1em;
+    margin-block-end: 1em;
+    margin-inline-start: 0px;
+    margin-inline-end: 0px;
+  }
+
+  h1 {
+    display: block;
+    font-size: 2em;
+    margin-block-start: 0.67em;
+    margin-block-end: 0.67em;
+    margin-inline-start: 0px;
+    margin-inline-end: 0px;
+    font-weight: bold;
+  }
+
+  h2 {
+    display: block;
+    font-size: 1.5em;
+    margin-block-start: 0.83em;
+    margin-block-end: 0.83em;
+    margin-inline-start: 0px;
+    margin-inline-end: 0px;
+    font-weight: bold;
+  }
+
+  h3 {
+    display: block;
+    font-size: 1.17em;
+    margin-block-start: 1em;
+    margin-block-end: 1em;
+    margin-inline-start: 0px;
+    margin-inline-end: 0px;
+    font-weight: bold;
+  }
+
+  strong {
+    font-weight: bold;
+  }
+
+  em {
+    font-style: italic;
+  }
+
+  u {
+    text-decoration: underline;
+  }
+
+  a:-webkit-any-link {
+    color: -webkit-link;
+    cursor: pointer;
+    text-decoration: underline;
+  }
+
+  li {
+    display: list-item;
+    text-align: -webkit-match-parent;
+  }
+
+  ol {
+    display: block;
+    margin-block-start: 1em;
+    margin-block-end: 1em;
+    margin-inline-start: 0px;
+    margin-inline-end: 0px;
+    padding-inline-start: 40px;
+
+    > li {
+      list-style-type: decimal;
+    }
+  }
+
+  ul {
+    display: block;
+    margin-block-start: 1em;
+    margin-block-end: 1em;
+    margin-inline-start: 0px;
+    margin-inline-end: 0px;
+    padding-inline-start: 40px;
+
+    > li {
+      list-style-type: disc;
+    }
+  }
+`;
+
+export default QuillContentBody;


### PR DESCRIPTION
#249 

css 리셋으로 인해 react quill로 작성한 본문에 스타일이 적용 안되는 문제 해결

게시글과 댓글에 적용했습니다.

src/styles 폴더 안에 QuillContentBody.style.ts에 스타일 컴포넌트 선언했습니다.
게시글 상세 페이지에서 게시글 본문 부분과 댓글 본문 부분의 스타일 컴포넌트에 QuillContentBody를 상속받도록 작성했습니다.

적용 예시 아래 링크에서 확인하시면 됩니다.
http://localhost:3000/postscript/32