### PR TITLE
client-jongwon: 수정, 삭제 권한에 따라 버튼 렌더링 여부 적용

### DIFF
--- a/client/src/components/Answer/AnswerContainer.tsx
+++ b/client/src/components/Answer/AnswerContainer.tsx
@@ -2,6 +2,8 @@ import * as S from './AnswerListView.style';
 import { Icon } from '@iconify/react';
 import { formatDistanceToNow } from 'date-fns';
 import { ko } from 'date-fns/locale';
+import { useRecoilValue } from 'recoil';
+import { logUser } from '../../atoms';
 
 interface HandlerProps {
   patchHandler: (e: React.MouseEvent<HTMLElement>) => void;
@@ -26,6 +28,7 @@ interface AnswerViewProps {
   editHandler: () => void;
   deleteHandler: (e: React.MouseEvent<HTMLElement>) => void;
 }
+
 export const AnswerViewContainer = ({
   nickname,
   updatedAt,
@@ -35,6 +38,10 @@ export const AnswerViewContainer = ({
 }: AnswerViewProps) => {
   const createTime = formatDistanceToNow(new Date(createdAt), { addSuffix: true, locale: ko });
   const updateTime = formatDistanceToNow(new Date(updatedAt), { addSuffix: true, locale: ko });
+
+  const logUserNickname = useRecoilValue(logUser).nickname;
+  const logUserMemberRole = useRecoilValue(logUser).memberRole;
+
   return (
     <S.UserAnswerInfo>
       <S.TimeOrName>
@@ -45,12 +52,14 @@ export const AnswerViewContainer = ({
         <span>{createTime !== updateTime ? <span>{updateTime}</span> : createTime} </span>
       </S.TimeOrName>
 
-      <div>
-        <S.AnswerButton onClick={editHandler}>수정</S.AnswerButton>
-        <S.AnswerButton color="red" onClick={deleteHandler}>
-          삭제
-        </S.AnswerButton>
-      </div>
+      {nickname === logUserNickname || logUserMemberRole === 'admin' ? (
+        <div>
+          <S.AnswerButton onClick={editHandler}>수정</S.AnswerButton>
+          <S.AnswerButton color="red" onClick={deleteHandler}>
+            삭제
+          </S.AnswerButton>
+        </div>
+      ) : null}
     </S.UserAnswerInfo>
   );
 };

--- a/client/src/components/Forum/ForumDetail.tsx
+++ b/client/src/components/Forum/ForumDetail.tsx
@@ -12,6 +12,8 @@ import { readPost, votePost } from '../../utils/api/forumAPI';
 import StudyAnswer from '../Answer/StudyAnswer';
 import ForumArticlesAnswer from '../Answer/ForumArticlesAnswer';
 import MentoringAnswer from '../Answer/MentoringAnswer';
+import { useRecoilValue } from 'recoil';
+import { logUser } from '../../atoms';
 
 interface PropsType {
   page?: number;
@@ -25,6 +27,8 @@ const ForumDetail = ({ page = 1 }: PropsType) => {
   const [, forumType, id] = pathname.split('/');
 
   const navigate = useNavigate();
+
+  const { nickname, memberRole } = useRecoilValue(logUser);
 
   useEffect(() => {
     const url = `/${forumType}/${id}`;
@@ -67,15 +71,17 @@ const ForumDetail = ({ page = 1 }: PropsType) => {
             </S.TagsContainer>
             <S.TitleContainer>
               <S.Title>{post[`${forumType}Title`]}</S.Title>
-              <MoreButton
-                buttonType="post"
-                forumType={forumType}
-                id={post[`${forumType}Id`]}
-                tagName={post.tagName}
-                title={post[`${forumType}Title`]}
-                content={post[`${forumType}Content`]}
-                author={post.member.nickname}
-              />
+              {nickname === post.member.nickname || memberRole === 'admin' ? (
+                <MoreButton
+                  buttonType="post"
+                  forumType={forumType}
+                  id={post[`${forumType}Id`]}
+                  tagName={post.tagName}
+                  title={post[`${forumType}Title`]}
+                  content={post[`${forumType}Content`]}
+                  author={post.member.nickname}
+                />
+              ) : null}
             </S.TitleContainer>
             <ForumWrittenInfo position="left" author={post.member.nickname} createdAt={createdAt} view={post.view} />
           </S.TitleInfoContainer>


### PR DESCRIPTION
#261 

1. 게시글 또는 댓글의 작성자의 nickname이 현재 로그인한 유저의 nickname과 같을 때
2. 로그인한 유저의 memberRole이 admin일 때

수정, 삭제 버튼이 렌더링되도록 작성했습니다.